### PR TITLE
Add dev proxy to avoid CORS errors

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,11 +4,15 @@ This project was generated using [Angular CLI](https://github.com/angular/angula
 
 ## Development server
 
-To start a local development server, run:
+To start a local development server without running into CORS issues, run:
 
 ```bash
-ng serve
+npm start
 ```
+
+The `npm start` script uses `proxy.conf.json` to forward API requests to
+`http://127.0.0.1:8000`, which allows the Angular app to communicate with the
+backend during development.
 
 Once the server is running, open your browser and navigate to `http://localhost:4200/`. The application will automatically reload whenever you modify any of the source files.
 

--- a/angular.json
+++ b/angular.json
@@ -69,6 +69,9 @@
         },
         "serve": {
           "builder": "@angular-devkit/build-angular:dev-server",
+          "options": {
+            "proxyConfig": "proxy.conf.json"
+          },
           "configurations": {
             "production": {
               "buildTarget": "hr-shorthandFE:build:production"

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "0.0.0",
   "scripts": {
     "ng": "ng",
-    "start": "ng serve",
+    "start": "ng serve --proxy-config proxy.conf.json",
     "build": "ng build",
     "watch": "ng build --watch --configuration development",
     "test": "ng test"

--- a/proxy.conf.json
+++ b/proxy.conf.json
@@ -1,0 +1,8 @@
+{
+  "/api": {
+    "target": "http://127.0.0.1:8000",
+    "secure": false,
+    "changeOrigin": true,
+    "logLevel": "debug"
+  }
+}

--- a/src/environments/environment.ts
+++ b/src/environments/environment.ts
@@ -1,4 +1,4 @@
 export const environment = {
   production: false,
-  apiUrl: 'http://127.0.0.1:8000/api'
+  apiUrl: '/api'
 };


### PR DESCRIPTION
## Summary
- configure Angular dev server to use a proxy
- use proxy in `npm start` and update README
- point `environment.ts` API base to `/api`

## Testing
- `npm test --silent -- --watch=false` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_686ac343f3e08327a3a1b81eec347bbf